### PR TITLE
feat: Adding missing APIs

### DIFF
--- a/config/actionsenvironmentsecret/config.go
+++ b/config/actionsenvironmentsecret/config.go
@@ -1,0 +1,17 @@
+package actionsenvironmentsecret
+
+import "github.com/crossplane/upjet/pkg/config"
+
+// Configure github_actions_environment_secret resource.
+func Configure(p *config.Provider) {
+	p.AddResourceConfigurator("github_actions_environment_secret", func(r *config.Resource) {
+		r.ShortGroup = "actions"
+
+		r.References["repository"] = config.Reference{
+			TerraformName: "github_repository",
+		}
+		r.References["environment"] = config.Reference{
+			TerraformName: "github_repository_environment",
+		}
+	})
+}

--- a/config/actionsenvironmentvariable/config.go
+++ b/config/actionsenvironmentvariable/config.go
@@ -1,0 +1,18 @@
+package actionsenvironmentvariable
+
+import "github.com/crossplane/upjet/pkg/config"
+
+// Configure github_actions_environment_variable resource.
+func Configure(p *config.Provider) {
+	p.AddResourceConfigurator("github_actions_environment_variable", func(r *config.Resource) {
+
+		r.ShortGroup = "actions"
+
+		r.References["repository"] = config.Reference{
+			TerraformName: "github_repository",
+		}
+		r.References["environment"] = config.Reference{
+			TerraformName: "github_repository_environment",
+		}
+	})
+}

--- a/config/actionsorganizationpermissions/config.go
+++ b/config/actionsorganizationpermissions/config.go
@@ -1,0 +1,15 @@
+package actionsorganizationpermissions
+
+import "github.com/crossplane/upjet/pkg/config"
+
+// Configure github_actions_organization_permissions resource.
+func Configure(p *config.Provider) {
+	p.AddResourceConfigurator("github_actions_organization_permissions", func(r *config.Resource) {
+
+		r.ShortGroup = "actions"
+
+		r.References["repository"] = config.Reference{
+			TerraformName: "github_repository",
+		}
+	})
+}

--- a/config/actionsorganizationvariable/config.go
+++ b/config/actionsorganizationvariable/config.go
@@ -1,0 +1,15 @@
+package actionsorganizationvariable
+
+import "github.com/crossplane/upjet/pkg/config"
+
+// Configure github_actions_organization_variable resource.
+func Configure(p *config.Provider) {
+	p.AddResourceConfigurator("github_actions_organization_variable", func(r *config.Resource) {
+
+		r.ShortGroup = "actions"
+
+		r.References["repository"] = config.Reference{
+			TerraformName: "github_repository",
+		}
+	})
+}

--- a/config/actionsrepositoryaccesslevel/config.go
+++ b/config/actionsrepositoryaccesslevel/config.go
@@ -1,0 +1,15 @@
+package actionsrepositoryaccesslevel
+
+import "github.com/crossplane/upjet/pkg/config"
+
+// Configure github_actions_repository_access_level resource.
+func Configure(p *config.Provider) {
+	p.AddResourceConfigurator("github_actions_repository_access_level", func(r *config.Resource) {
+
+		r.ShortGroup = "actions"
+
+		r.References["repository"] = config.Reference{
+			TerraformName: "github_repository",
+		}
+	})
+}

--- a/config/actionsrepositorypermissions/config.go
+++ b/config/actionsrepositorypermissions/config.go
@@ -1,0 +1,15 @@
+package actionsrepositorypermissions
+
+import "github.com/crossplane/upjet/pkg/config"
+
+// Configure github_actions_repository_permissions resource.
+func Configure(p *config.Provider) {
+	p.AddResourceConfigurator("github_actions_repository_permissions", func(r *config.Resource) {
+
+		r.ShortGroup = "actions"
+
+		r.References["repository"] = config.Reference{
+			TerraformName: "github_repository",
+		}
+	})
+}

--- a/config/branchprotectionv3/config.go
+++ b/config/branchprotectionv3/config.go
@@ -1,0 +1,15 @@
+package branchprotectionv3
+
+import "github.com/crossplane/upjet/pkg/config"
+
+// Configure github_branch_protection_v3 resource.
+func Configure(p *config.Provider) {
+	p.AddResourceConfigurator("github_branch_protection_v3", func(r *config.Resource) {
+		r.Kind = "BranchProtectionv3"
+		r.ShortGroup = "repo"
+
+		r.References["repository"] = config.Reference{
+			TerraformName: "github_repository",
+		}
+	})
+}

--- a/config/issuelabels/config.go
+++ b/config/issuelabels/config.go
@@ -1,0 +1,15 @@
+package issuelabels
+
+import "github.com/crossplane/upjet/pkg/config"
+
+// Configure github_issue_label resource.
+func Configure(p *config.Provider) {
+	p.AddResourceConfigurator("github_issue_labels", func(r *config.Resource) {
+		r.Kind = "IssueLabels"
+		r.ShortGroup = "repo"
+
+		r.References["repository "] = config.Reference{
+			TerraformName: "github_repository",
+		}
+	})
+}

--- a/config/repositoryenvironment/config.go
+++ b/config/repositoryenvironment/config.go
@@ -1,0 +1,25 @@
+package repositoryenvironment
+
+import (
+	"github.com/crossplane/upjet/pkg/config"
+)
+
+// Configure github_repository_environment resource.
+func Configure(p *config.Provider) {
+	p.AddResourceConfigurator("github_repository_environment", func(r *config.Resource) {
+		r.Kind = "RepositoryEnvironment"
+		r.ShortGroup = "repo"
+
+		r.References["repository"] = config.Reference{
+			TerraformName: "github_repository",
+		}
+
+		r.References["reviewers.teams"] = config.Reference{
+			TerraformName: "github_team",
+		}
+
+		r.References["reviewers.users"] = config.Reference{
+			TerraformName: "github_membership",
+		}
+	})
+}

--- a/config/repositoryenvironmentdeploymentpolicy/config.go
+++ b/config/repositoryenvironmentdeploymentpolicy/config.go
@@ -1,0 +1,19 @@
+package repositoryenvironmentdeploymentpolicy
+
+import (
+	"github.com/crossplane/upjet/pkg/config"
+)
+
+// Configure github_repository_environment_deployment_policy resource.
+func Configure(p *config.Provider) {
+	p.AddResourceConfigurator("github_repository_environment_deployment_policy", func(r *config.Resource) {
+		r.ShortGroup = "repo"
+
+		r.References["repository"] = config.Reference{
+			TerraformName: "github_repository",
+		}
+		r.References["environment"] = config.Reference{
+			TerraformName: "github_repository_environment",
+		}
+	})
+}

--- a/config/repositorytagprotection/config.go
+++ b/config/repositorytagprotection/config.go
@@ -1,0 +1,17 @@
+package repositorytagprotection
+
+import (
+	"github.com/crossplane/upjet/pkg/config"
+)
+
+// Configure github_repository_tag_protection resource.
+func Configure(p *config.Provider) {
+	p.AddResourceConfigurator("github_repository_tag_protection", func(r *config.Resource) {
+
+		r.ShortGroup = "repo"
+
+		r.References["repository"] = config.Reference{
+			TerraformName: "github_repository",
+		}
+	})
+}

--- a/config/teammembers/config.go
+++ b/config/teammembers/config.go
@@ -1,0 +1,14 @@
+package teammembers
+
+import "github.com/crossplane/upjet/pkg/config"
+
+// Configure github_team_membership resource
+func Configure(p *config.Provider) {
+	p.AddResourceConfigurator("github_team_members", func(r *config.Resource) {
+		r.ShortGroup = "team"
+
+		r.References["team_id"] = config.Reference{
+			TerraformName: "github_team",
+		}
+	})
+}


### PR DESCRIPTION
### Description of your changes

I would like to merge https://github.com/xunholy/provider-github into this repository to align on a single source for the communities benefit rather than maintaining two separate packages. I originally started my own package as this one was missing key criteria, and some API groups were not correct when running this in our enterprise.

This needs to still generate the remaining files via `make` however, if someone else has some time to do that it would be greatly appreciated. 

Feel free to ask any questions related to any of these changes and/or improvements 🙏 
