### PR TITLE
fix: repository ruleset failing with incorrect external-name

### DIFF
--- a/config/external_name.go
+++ b/config/external_name.go
@@ -67,7 +67,7 @@ var terraformPluginSDKExternalNameConfigs = map[string]config.ExternalName{
 	// No documentation on how to import
 	"github_repository_pull_request": config.IdentifierFromProvider,
 	// Can be imported using the following format: {{ repository }}:{{ ruleset id }}
-	"github_repository_ruleset": config.IdentifierFromProvider,
+	"github_repository_ruleset": config.TemplatedStringAsIdentifier("repository", "{{ .parameters.repository }}:{{ .external_name }}"),
 	// Can be imported using the following format: {{ repository }}:{{ tag protection id }}
 	"github_repository_tag_protection": config.IdentifierFromProvider,
 	// Can be imported using the following format: {{ repository }}/{{ id }}.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This atempts to fix the external-name with the `Repository Ruleset` resource as documented in issue #176 - I've had issues locally running the `make` commands if someone could please assist there.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #176 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
